### PR TITLE
약속 문자열에 \u나 \x가 있으면 오류 발생

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -180,6 +180,10 @@ const code19 = `
 사전.키1 + 사전.키2 보여주기
 `;
 
+const code20 = `
+문자열: "\\u <잘못된 문자입니다> 에러를 출력하거나, 일반 u 문자로 취급되도록 수정 필요"
+`;
+
 function test_lexer(code) {
     let lexer = new YaksokLexer();
     lexer.setInput(code);
@@ -206,7 +210,7 @@ async function test_compiler(code) {
     console.log();
 }
 
-let code = code19;
+let code = code20;
 console.log(code + '\n');
 // test_lexer(code);
 // test_parser(code);


### PR DESCRIPTION
lexer.js에 정의된 정규표현식 패턴 `/"([^\\"]|\\.)*"|'([^\\']|\\.)*'/`과 [JS 문자열 이스케이프 표기법](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Escape_notation)에 차이가 있습니다. \u나 \x 등을 잘못 사용하는 경우 정규표현식 비교는 통과하지만 parseString 함수에서 에러가 나기 때문에 이 경우 오류 메시지가 약속 컴파일러의 `잘못된 문자입니다` 오류 대신 JS의 `Uncaught SyntaxError`가 발생합니다.

1. \u나 \x 이스케이프 검증을 regex 단계로 옮기기
2. \u나 \x는 일반 문자 u와 x로 치환하기

두 가지 옵션이 있을 것 같네요. 어느걸로 할까요 ㄹㄹ

eval에 보안 구멍이 있나 없나 열심히 보다가 이런 허접한 버그나 찾고 있네요 ㅜㅜ